### PR TITLE
Add functions to calculate synthetic transmission spectrum

### DIFF
--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -2,5 +2,5 @@ Core hierarchy
 ==============
 Core classes to store and process model output.
 
-.. autoclass:: aeolus.core.AtmosFlow
+.. autoclass:: aeolus.core.AtmoSim
 .. autoclass:: aeolus.core.Run

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -25,3 +25,4 @@ overall workflow, you are better off starting in the :ref:`examples` section of 
    plot
    region
    subset
+   synthobs

--- a/docs/source/api/synthobs.rst
+++ b/docs/source/api/synthobs.rst
@@ -1,0 +1,7 @@
+Synthetic observations
+======================
+
+.. autofunction:: aeolus.synthobs.read_spectral_bands
+.. autofunction:: aeolus.synthobs.read_normalized_stellar_flux
+.. autofunction:: aeolus.synthobs.calc_stellar_flux
+.. autofunction:: aeolus.synthobs.calc_transmission_spectrum_day_night_average

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 :Date: TBA
 
 * Add more names to `model.base`
+* Add functions to calculate synthetic transmission spectrum
 
 
 0.4.9

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -199,7 +199,7 @@ epub_exclude_files = ["search.html"]
 # Options for intersphinx.
 intersphinx_mapping = {
     "cartopy": ("https://scitools.org.uk/cartopy/docs/latest/", None),
-    "iris": ("https://scitools.org.uk/iris/docs/latest/", None),
+    "iris": ("https://scitools-iris.readthedocs.io/en/latest/", None),
     "matplotlib": ("https://matplotlib.org", None),
     "mpl_toolkits": ("https://matplotlib.org", None),
     "numpy": ("https://numpy.org/doc/stable", None),

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,7 +22,7 @@ See also
 - The `iris`_ package, upon which aeolus relies heavily.
 - The repository with `code`_ used for the figures in `Sergeev et al. (2020) <https://arxiv.org/abs/2004.03007>`_.
 
-.. _iris: https://scitools.org.uk/iris/docs/latest/
+.. _iris: https://scitools-iris.readthedocs.io/en/latest/
 .. _code: https://github.com/dennissergeev/exoconvection-apj-2020
 
 

--- a/src/aeolus/model/base.py
+++ b/src/aeolus/model/base.py
@@ -9,6 +9,9 @@ __all__ = "Model"
 class Model:
     """Base class for model-specific names."""
 
+    def __hash__(self):  # noqa
+        return hash(id(self))
+
     # Coordinates
     t: str = None  # time
     fcst_ref: str = None  # forecast reference

--- a/src/aeolus/synthobs.py
+++ b/src/aeolus/synthobs.py
@@ -1,0 +1,252 @@
+from pathlib import Path
+
+import iris
+import numpy as np
+from iris.analysis.maths import apply_ufunc
+from iris.util import reverse
+
+from ..coord import isel, roll_cube_pm180
+from ..model import um
+
+
+__all__ = (
+    "read_spectral_bands",
+    "read_normalized_stellar_flux",
+    "calc_stellar_flux",
+    "calc_transmission_spectrum_day_night_average",
+)
+
+
+def read_spectral_bands(spectral_file):
+    """
+    Read spectral bands from a SOCRATES spectral file used by the Met Office Unified Model.
+
+    Parameters
+    ----------
+    spectral_file: pathlib.PosixPath
+        Path to the location of a SOCRATES spectral file used by the Met Office Unified Model.
+
+    Returns
+    -------
+    numpy.ndarray
+        An array with a list of tuples describing spectral bands.
+        Tuple structure: (spectral_band_index, lower_wavelength_limit, upper_wavelength_limit).
+        Units [m] as stated in a SOCRATES spectral file but not checked directly.
+    """
+    with spectral_file.open("r") as f:
+        lines = []
+        band_block = False
+        for line in f:
+            if line.startswith("*BLOCK: TYPE =    1"):
+                band_block = True
+            if band_block:
+                if line.startswith("*END"):
+                    break
+                elif line.lstrip().split(" ")[0].isnumeric():
+                    lines.append(
+                        tuple([float(i) for i in line.lstrip().rstrip("\n").split(" ") if i])
+                    )
+    spectral_bands = np.array(
+        lines,
+        dtype=[
+            ("spectral_band_index", "u4"),
+            ("lower_wavelength_limit", "f4"),
+            ("upper_wavelength_limit", "f4"),
+        ],
+    )
+    return spectral_bands
+    
+    
+    def read_normalized_stellar_flux(spectral_file):
+    """
+    Read the normalized stellar flux per spectral band from a SOCRATES spectral file
+    used by the Met Office Unified Model.
+
+    Parameters
+    ----------
+    spectral_file: pathlib.PosixPath
+        Path to the location of a SOCRATES spectral file used by the Met Office Unified Model.
+
+    Returns
+    -------
+    iris.cube.Cube
+        Normalized stellar flux per spectral band [1].
+    """
+    with spectral_file.open("r") as f:
+        lines = []
+        band_block = False
+        for line in f:
+            if line.startswith("*BLOCK: TYPE =    2"):
+                band_block = True
+            if band_block:
+                if line.startswith("*END"):
+                    break
+                elif line.lstrip().split(" ")[0].isnumeric():
+                    lines.append(
+                        tuple([float(i) for i in line.lstrip().rstrip("\n").split(" ") if i])
+                    )
+    normalized_stellar_flux_arr = np.array(
+        lines, dtype=[("spectral_band_index", "u4"), ("normalized_stellar_flux", "f4")]
+    )
+    # Compose an iris cube
+    spectral_band_index = iris.coords.DimCoord(
+        normalized_stellar_flux_arr["spectral_band_index"],
+        long_name="spectral_band_index",
+        units="1",
+    )
+    normalized_stellar_flux = iris.cube.Cube(
+        normalized_stellar_flux_arr["normalized_stellar_flux"],
+        long_name="normalized_stellar_flux",
+        dim_coords_and_dims=[(spectral_band_index, 0)],
+        units="1",
+    )
+    return normalized_stellar_flux
+    
+    
+    def calc_stellar_flux(spectral_file, stellar_constant_at_1_au):
+    """
+    Calculate the stellar flux per spectral band.
+
+    Parameters
+    ----------
+    spectral_file: pathlib.PosixPath
+        Path to the location of a SOCRATES spectral file used by the Met Office Unified Model.
+    stellar_constant_at_1_au: float or iris.cube.Cube
+        Stellar constant at 1 AU [W m-2].
+
+    Returns
+    -------
+    iris.cube.Cube
+        Stellar flux per spectral band [W m-2].
+    """
+    # Ensure that an input constant is an iris cube
+    if not isinstance(stellar_constant_at_1_au, iris.cube.Cube):
+        stellar_constant_at_1_au = iris.cube.Cube(
+            stellar_constant_at_1_au,
+            long_name="stellar_constant_at_1_au",
+            units="W m-2",
+        )
+    normalized_stellar_flux = read_normalized_stellar_flux(spectral_file)
+    stellar_flux = normalized_stellar_flux * stellar_constant_at_1_au
+    stellar_flux.rename("stellar_flux")
+    return stellar_flux
+    
+    
+    def calc_transmission_spectrum_day_night_average(
+    spectral_file,
+    stellar_constant_at_1_au,
+    stellar_radius,
+    planet_top_of_atmosphere,
+    planet_transmission_day,
+    planet_transmission_night,
+):
+    """
+    Calculate the synthetic transmission spectrum averaged over the dayside and the nightside.
+
+    Parameters
+    ----------
+    spectral_file: pathlib.PosixPath
+        Path to the location of a SOCRATES spectral file used by the Met Office Unified Model.
+    stellar_constant_at_1_au: float or iris.cube.Cube
+        Stellar constant at 1 AU [W m-2].
+    stellar_radius: float or iris.cube.Cube
+        Stellar radius [m].
+    planet_top_of_atmosphere: float or iris.cube.Cube
+        The extent of the planetary atmosphere [m].
+    planet_transmission_day: pathlib.PosixPath
+        Path to the location of the Met Office Unified Model output of STASH item m01s01i755
+        (in the case of hot Jupiters) from the dayside calculation.
+    planet_transmission_night: pathlib.PosixPath
+        Path to the location of the Met Office Unified Model output of STASH item m01s01i755
+        (in the case of hot Jupiters) from the nightside calculation.
+
+    Returns
+    -------
+    iris.cube.Cube
+        The ratio of the effective planetary radius to the stellar radius per spectral band [1].
+
+    Notes
+    -------
+    The transmission spectrum is the ratio of the effective planetary radius to the stellar
+    radius calculated per spectral band:
+
+    .. math::
+
+        \frac{R_p (\nu)}{R_s} = \sqrt{(\frac{R_{p,TOA}}{R_s})^2 - \frac{\sum_{lat,lon}^{}F_{transmitted} (\nu)}{F_{stellar} (\nu)}}
+
+    where R_p(\nu) is the effective planetary radius,
+    R_s is the stellar radius,
+    R_{p,TOA} is the extent of the planetary atmosphere (which usually is the sum of
+    the planetary radius and the height of the model domain),
+    \sum_{lat,lon}^{}F_{transmitted}(\nu) is the total transmitted flux,
+    F_{stellar}(\nu) is the stellar flux.
+    """
+    # Ensure that input constants are iris cubes
+    if not isinstance(stellar_constant_at_1_au, iris.cube.Cube):
+        stellar_constant_at_1_au = iris.cube.Cube(
+            stellar_constant_at_1_au,
+            long_name="stellar_constant_at_1_au",
+            units="W m-2",
+        )
+    if not isinstance(stellar_radius, iris.cube.Cube):
+        stellar_radius = iris.cube.Cube(
+            stellar_radius,
+            long_name="stellar_radius",
+            units="m",
+        )
+    if not isinstance(planet_top_of_atmosphere, iris.cube.Cube):
+        planet_top_of_atmosphere = iris.cube.Cube(
+            planet_top_of_atmosphere,
+            long_name="planet_top_of_atmosphere",
+            units="m",
+        )
+
+    # Load UM output from the dayside calculation
+    day = iris.load_cube(planet_transmission_day)
+    day_lon_coord = day.coord("longitude")
+
+    # Load UM output from the nightside calculation
+    # Roll nightside data by 180 degrees
+    night_rolled = roll_cube_pm180(iris.load_cube(planet_transmission_night))
+    # Reverse longitude order
+    night = reverse(night_rolled, night_rolled.coord_dims("longitude"))
+    # Replace the longitude coordinate to be able to do maths with iris
+    night.replace_coord(day_lon_coord)
+
+    # Use the same name for the spectral band index coordinate
+    for i in day.coords():
+        if i.name() in ["pseudo", "pseudo_level"]:
+            day.coord(i.name()).rename("spectral_band_index")
+    for i in night.coords():
+        if i.name() in ["pseudo", "pseudo_level"]:
+            night.coord(i.name()).rename("spectral_band_index")
+
+    # Calculate the geometric mean of the dayside and nightside transmitted flux
+    # and sum this flux over all latitudes and longitudes
+    transmitted_flux = apply_ufunc(np.sqrt, day * night, in_place=True).collapsed(
+        ["latitude", "longitude"], iris.analysis.SUM
+    )
+    transmitted_flux.rename("total_transmitted_flux")
+    transmitted_flux.units = "W m-2"
+
+    # Calculate stellar flux
+    stellar_flux = calc_stellar_flux(spectral_file, stellar_constant_at_1_au)
+
+    # Calculate the ratio of the total transmitted flux to the stellar flux
+    flux_ratio = transmitted_flux.copy(data=transmitted_flux.core_data() / stellar_flux.core_data())
+    flux_ratio.rename("flux_ratio")
+    flux_ratio.units = transmitted_flux.units / stellar_flux.units
+
+    # Calculate the ratio of the effective planetary radius to the stellar radius
+    rp_eff_over_rs_squared = (planet_top_of_atmosphere / stellar_radius) ** 2 - flux_ratio
+    rp_eff_over_rs_squared.data[rp_eff_over_rs_squared.data < 0.0] = 0.0
+    rp_eff_over_rs = rp_eff_over_rs_squared ** (0.5)
+    rp_eff_over_rs.rename("radius_ratio")
+
+    # Find spectral band centers
+    spectral_bands = read_spectral_bands(spectral_file)
+    spectral_band_centers = 0.5 * (
+        spectral_bands["lower_wavelength_limit"] + spectral_bands["upper_wavelength_limit"]
+    )
+
+    return spectral_band_centers, rp_eff_over_rs


### PR DESCRIPTION
Functions added:

- `read_spectral_bands()`
- `read_normalized_stellar_flux()`
- `calc_stellar_flux()`
- `calc_transmission_spectrum_day_night_average()`

Required inputs:

1. `spectral_file` - SOCRATES spectral file used by the UM
2. `stellar_constant_at_1_au` in [W m-2]
3. `stellar_radius` in [m]
4. `planet_top_of_atmosphere` in [m]
5. `planet_transmission_day` - UM m01s01i755 output (for hot Jupiters) from the dayside calculation
6. `planet_transmission_night` - UM m01s01i755 output (for hot Jupiters) from the nightside calculation

How get the required UM output, please read [http://exoclimatology.com/wiki/index.php?title=Transmission_Spectra](url)

Addresses #12 